### PR TITLE
feat: Add vault tabs in Vault details UI

### DIFF
--- a/pages/strategies/collateral-swap.tsx
+++ b/pages/strategies/collateral-swap.tsx
@@ -3,13 +3,16 @@ import { NextPage } from 'next'
 import { RequiredConnection } from '@/src/components/helpers/RequiredConnection'
 import { CollateralSwapContent } from '@/src/pagePartials/strategy/strategies/collateralSwap/CollateralSwapContent'
 import { CollateralSwapStore } from '@/src/pagePartials/strategy/strategies/collateralSwap/CollateralSwapStore'
+import VaultModalProvider from '@/src/providers/vaultModalProvider'
 
 const CollateralSwap: NextPage = () => {
   return (
     <RequiredConnection>
-      <CollateralSwapStore>
-        <CollateralSwapContent />
-      </CollateralSwapStore>
+      <VaultModalProvider>
+        <CollateralSwapStore>
+          <CollateralSwapContent />
+        </CollateralSwapStore>
+      </VaultModalProvider>
     </RequiredConnection>
   )
 }

--- a/src/components/asset/PositionHead.tsx
+++ b/src/components/asset/PositionHead.tsx
@@ -102,12 +102,11 @@ const Collapsable = styled(HeadInnerCollapsable)`
 `
 
 interface Props {
-  positionTokens: any
-  value: string
+  position: any
 }
 
-export const PositionHead: React.FC<Props> = ({ positionTokens, value, ...restProps }) => {
-  const { status, tokens, type } = positionTokens
+export const PositionHead: React.FC<Props> = ({ position, ...restProps }) => {
+  const { status, tokens, type, value } = position
   const notCollateralSwap = type === 'long' || type === 'short'
   const [isOpen, setIsOpen] = useState(false)
 

--- a/src/hooks/queries/useGetUserVaults.tsx
+++ b/src/hooks/queries/useGetUserVaults.tsx
@@ -9,6 +9,11 @@ import {
   Swapper_UserProxyImplementation__factory,
 } from '@/types/generated/typechain'
 
+export type VaultData = {
+  name: string
+  vaultAddress: string
+}
+
 export const useGetUserVaults = () => {
   const { address, batchProvider } = useWeb3ConnectedApp()
   const SwapperCoordinatorContract = useContractInstance(
@@ -30,7 +35,7 @@ export const useGetUserVaults = () => {
       ? { key: `vaultList-names-${address}`, vaultAddresses: vaultAddresses[0] }
       : null,
     async ({ vaultAddresses }) => {
-      const results = await Promise.all(
+      const results: VaultData[] = await Promise.all(
         vaultAddresses.map(async (vaultAddress) => {
           const contract = Swapper_UserProxyImplementation__factory.connect(
             vaultAddress,

--- a/src/pagePartials/strategy/positions/HistoryList.tsx
+++ b/src/pagePartials/strategy/positions/HistoryList.tsx
@@ -10,37 +10,31 @@ export const HistoryList: React.FC = withGenericSuspense(
   ({ ...restProps }) => {
     const mockedData = [
       {
-        positionTokens: {
-          type: 'long',
-          status: 'closed',
-          tokens: [
-            { symbol: 'usdc', value: '14,000.00' },
-            { symbol: 'xdai', value: '9,146,465.00' },
-          ],
-        },
+        type: 'long',
+        status: 'closed',
+        tokens: [
+          { symbol: 'usdc', value: '14,000.00' },
+          { symbol: 'xdai', value: '9,146,465.00' },
+        ],
         value: '<0.000001 WXDAI',
       },
       {
-        positionTokens: {
-          type: 'collateralSwap',
-          status: 'closed',
-          tokens: [
-            { symbol: 'usdc', value: '4,000.00' },
-            { symbol: 'xdai', value: '19,146,465.00' },
-          ],
-        },
+        type: 'collateralSwap',
+        status: 'closed',
+        tokens: [
+          { symbol: 'usdc', value: '4,000.00' },
+          { symbol: 'xdai', value: '19,146,465.00' },
+        ],
         value: '1 USDC = 10.000034 XDAI',
       },
 
       {
-        positionTokens: {
-          type: 'short',
-          status: 'closed',
-          tokens: [
-            { symbol: 'usdc', value: '14,000.00' },
-            { symbol: 'xdai', value: '9,146,465.00' },
-          ],
-        },
+        type: 'short',
+        status: 'closed',
+        tokens: [
+          { symbol: 'usdc', value: '14,000.00' },
+          { symbol: 'xdai', value: '9,146,465.00' },
+        ],
         value: '<0.000001 WXDAI',
       },
     ]

--- a/src/pagePartials/strategy/positions/Position.tsx
+++ b/src/pagePartials/strategy/positions/Position.tsx
@@ -18,11 +18,9 @@ interface Props extends PropsWithChildren {
 }
 
 export const Position: React.FC<Props> = ({ children, data, ...restProps }) => {
-  const { positionTokens, value } = data
-
   return (
     <Wrapper {...restProps}>
-      <PositionHead positionTokens={positionTokens} value={value} />
+      <PositionHead position={data} />
       {children && <Body>{children}</Body>}
     </Wrapper>
   )

--- a/src/pagePartials/strategy/positions/PositionsList.tsx
+++ b/src/pagePartials/strategy/positions/PositionsList.tsx
@@ -17,36 +17,30 @@ export const PositionsList: React.FC = withGenericSuspense(
   ({ ...restProps }) => {
     const mockedData = [
       {
-        positionTokens: {
-          type: 'collateralSwap',
-          status: 'open',
-          tokens: [
-            { symbol: 'usdc', value: '4,000.00' },
-            { symbol: 'xdai', value: '19,146,465.00' },
-          ],
-        },
+        type: 'collateralSwap',
+        status: 'open',
+        tokens: [
+          { symbol: 'usdc', value: '4,000.00' },
+          { symbol: 'xdai', value: '19,146,465.00' },
+        ],
         value: '1 USDC = 10.000034 XDAI',
       },
       {
-        positionTokens: {
-          type: 'long',
-          status: 'open',
-          tokens: [
-            { symbol: 'usdc', value: '14,000.00' },
-            { symbol: 'xdai', value: '9,146,465.00' },
-          ],
-        },
+        type: 'long',
+        status: 'open',
+        tokens: [
+          { symbol: 'usdc', value: '14,000.00' },
+          { symbol: 'xdai', value: '9,146,465.00' },
+        ],
         value: '<0.000001 WXDAI',
       },
       {
-        positionTokens: {
-          type: 'short',
-          status: 'open',
-          tokens: [
-            { symbol: 'usdc', value: '14,000.00' },
-            { symbol: 'xdai', value: '9,146,465.00' },
-          ],
-        },
+        type: 'short',
+        status: 'open',
+        tokens: [
+          { symbol: 'usdc', value: '14,000.00' },
+          { symbol: 'xdai', value: '9,146,465.00' },
+        ],
         value: '<0.000001 WXDAI',
       },
     ]

--- a/src/pagePartials/strategy/strategies/StrategyContainer.tsx
+++ b/src/pagePartials/strategy/strategies/StrategyContainer.tsx
@@ -1,9 +1,12 @@
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { FC, PropsWithChildren } from 'react'
 import styled from 'styled-components'
 
+import { ButtonGoTo } from '@/src/components/buttons/ButtonGoTo'
 import { BaseTitle } from '@/src/components/text/BaseTitle'
 import { StrategiesDropdown } from '@/src/pagePartials/strategy/common/StrategiesDropdown'
+import { useVaultModalContext } from '@/src/providers/vaultModalProvider'
 import { Strategy } from '@/types/strategy'
 
 const Title = styled(BaseTitle)`
@@ -11,13 +14,21 @@ const Title = styled(BaseTitle)`
   text-transform: capitalize;
 `
 
-export const StrategyContainer: FC<
-  PropsWithChildren<{ strategy: Strategy['slug']; vaultAddress: string }>
-> = ({ children, strategy, vaultAddress }) => {
+const Wrapper = styled.div`
+  min-height: 500px;
+`
+
+export const StrategyContainer: FC<PropsWithChildren<{ strategy: Strategy['slug'] }>> = ({
+  children,
+  strategy,
+}) => {
   const router = useRouter()
+  const { vaultAddress } = useVaultModalContext()
 
   return (
-    <>
+    <Wrapper>
+      <Link href={`/strategies/vault-details?vault=${vaultAddress}`}>{'<'} Back to vault</Link>
+      <br />
       <Title>Strategies</Title>
       <StrategiesDropdown
         onChange={(selectedStrategy) =>
@@ -26,6 +37,6 @@ export const StrategyContainer: FC<
         strategy={strategy}
       />
       {children}
-    </>
+    </Wrapper>
   )
 }

--- a/src/pagePartials/strategy/strategies/collateralSwap/CollateralSwapContent.tsx
+++ b/src/pagePartials/strategy/strategies/collateralSwap/CollateralSwapContent.tsx
@@ -201,7 +201,7 @@ export const CollateralSwapContent: FC = ({ ...restProps }) => {
     state.destinationAmount === '0'
 
   return (
-    <StrategyContainer strategy="collateral-swap" vaultAddress={vaultAddress}>
+    <StrategyContainer strategy="collateral-swap">
       <form onSubmit={handleSwapRequest}>
         <FormCard {...restProps}>
           <OriginToken />


### PR DESCRIPTION
# Description

Adding New Strategy, History and Positions tabs in vault details with mock data.

Closes #10 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Go to strategies page
- [ ] Select a previously created vault
- [ ] In the vault details page you can see the 3 tabs mentioned.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
