### PR TITLE
fix: jumper link directly to the bridge pair

### DIFF
--- a/src/pagePartials/sdai/deposit/InitialDepositStep.tsx
+++ b/src/pagePartials/sdai/deposit/InitialDepositStep.tsx
@@ -35,7 +35,10 @@ const InitialDepositStepInfo: React.FC<InitialDepositStepInfoProps> = ({
       <Text>
         Need to bridge assets to Gnosis
         <br />
-        from other chains? Consider using <a href="https://jumper.exchange/">jumper</a>
+        from other chains? Consider using{' '}
+        <a href="https://jumper.exchange/?fromChain=1&fromToken=0x6b175474e89094c44da98b954eedeac495271d0f&toChain=100&toToken=0x0000000000000000000000000000000000000000">
+          jumper
+        </a>
       </Text>
       <Row>
         <RowKey>Available to deposit</RowKey>

--- a/src/pagePartials/sdai/redeem/InitialRedeemStep.tsx
+++ b/src/pagePartials/sdai/redeem/InitialRedeemStep.tsx
@@ -35,7 +35,10 @@ const InitialRedeemStepInfo: React.FC<InitialRedeemStepInfoProps> = ({
       <Text>
         Need to bridge assets to Gnosis
         <br />
-        from other chains? Consider using <a href="https://jumper.exchange/">jumper</a>
+        from other chains? Consider using{' '}
+        <a href="https://jumper.exchange/?fromChain=1&fromToken=0x6b175474e89094c44da98b954eedeac495271d0f&toChain=100&toToken=0x0000000000000000000000000000000000000000">
+          jumper
+        </a>
       </Text>
       <Row>
         <RowKey>Available to redeem</RowKey>


### PR DESCRIPTION
Stop linking to jumper... and link directly to the correct pair because they are listing too many DAI tokens that are leading to user mistakes